### PR TITLE
GetPasswordを変更

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -41,11 +41,10 @@ do
     echo "パスワードの追加は成功しました。"
   elif [ "${input}" = "Get Password" ]; then
     if [ -e password_info.txt.gpg ]; then
-      gpg -d password_info.txt.gpg > password_info.txt
-
       echo -n "サービス名を入力してください："
       read input
 
+      gpg -d password_info.txt.gpg > password_info.txt
       result=$(grep  $input password_info.txt)
 
       rm password_info.txt


### PR DESCRIPTION
GetPasswordを選択した際、これまではサービス名を入力する前に暗号化ファイルを復号していましたが、サービス名を入力した後に復号するようにしました。
以前まではサービス名の入力中は複合化されたパスワードファイルを見ることができました。
サービス名を入力した後に暗号化ファイルを複合し、入力されたサービス名の情報を変数に代入しすぐ削除することで複合化されたファイルの存在時間を短くしました。